### PR TITLE
Make sbt the entrypoint

### DIFF
--- a/jdk11/alpine/Dockerfile
+++ b/jdk11/alpine/Dockerfile
@@ -24,7 +24,7 @@ RUN set -x \
 
 WORKDIR /opt/workspace
 
-ENTRYPOINT /bin/bash
+ENTRYPOINT ["sbt"]
 
 ENV PATH="/opt/sbt/sbt/bin:$PATH" \
     JAVA_OPTS="-XX:+UseContainerSupport -Dfile.encoding=UTF-8" \

--- a/jdk11/alpine/Dockerfile.mustache
+++ b/jdk11/alpine/Dockerfile.mustache
@@ -24,7 +24,7 @@ RUN set -x \
 
 WORKDIR /opt/workspace
 
-ENTRYPOINT /bin/bash
+ENTRYPOINT ["sbt"]
 
 ENV PATH="/opt/sbt/sbt/bin:$PATH" \
     JAVA_OPTS="-XX:+UseContainerSupport -Dfile.encoding=UTF-8" \

--- a/jdk8/alpine/Dockerfile
+++ b/jdk8/alpine/Dockerfile
@@ -24,7 +24,7 @@ RUN set -x \
 
 WORKDIR /opt/workspace
 
-ENTRYPOINT /bin/bash
+ENTRYPOINT ["sbt"]
 
 ENV PATH="/opt/sbt/sbt/bin:$PATH" \
     JAVA_OPTS="-XX:+UseContainerSupport -Dfile.encoding=UTF-8" \

--- a/jdk8/alpine/Dockerfile.mustache
+++ b/jdk8/alpine/Dockerfile.mustache
@@ -24,7 +24,7 @@ RUN set -x \
 
 WORKDIR /opt/workspace
 
-ENTRYPOINT /bin/bash
+ENTRYPOINT ["sbt"]
 
 ENV PATH="/opt/sbt/sbt/bin:$PATH" \
     JAVA_OPTS="-XX:+UseContainerSupport -Dfile.encoding=UTF-8" \


### PR DESCRIPTION
With this we can do:
```
docker run -ti eed3si9n/sbt test
```
No need to specify `sbt`.

Addresses also https://github.com/eed3si9n/docker-sbt/issues/1

It would be cool if we tag newer versions `1.3.6-jdk8-alpine` instead of `sbt1.3.6-jdk8-alpine`. Seems like the `sbt` is redundant here.